### PR TITLE
Change way to get user username

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pwd
 import datetime
 import sys
 import asyncio
@@ -10,6 +9,14 @@ from opsdroid.connector import Connector
 from opsdroid.message import Message
 
 reader, writer = None, None
+
+
+def get_username():
+    for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
+        user = os.environ.get(name)
+        if user != 'None':
+            return user
+
 
 async def stdio(loop=None):
     if loop is None:
@@ -58,7 +65,7 @@ class ConnectorShell(Connector):
         """Listen for new user input."""
         logging.debug("Connecting to shell")
         while True:
-            user = pwd.getpwuid(os.getuid())[0]
+            user = get_username()
             self.draw_prompt()
             user_input = await async_input('', opsdroid.eventloop)
             message = Message(user_input, user, None, self)

--- a/__init__.py
+++ b/__init__.py
@@ -71,7 +71,7 @@ class ConnectorShell(Connector):
             message = Message(user_input, user, None, self)
             await opsdroid.parse(message)
 
-    async def respond(self, message):
+    async def respond(self, message, room=None):
         """Respond with a message."""
         logging.debug("Responding with: " + message.text)
         self.clear_prompt()


### PR DESCRIPTION
The python module `pwd` can't be run on windows due to the fact that windows lacks this command from the command line, so this connector crashes every time a user attempts to run opsdroid from the command line on windows.

In order to fix this issue I created a get_username function that takes the username from `os.environ`, 
@sbeesm tried to run this fix and opsdroid ran this connector without any issue.