### PR TITLE
Fix exception Connector can not handle the 'Message' event type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -5,8 +5,8 @@ import sys
 import platform
 import asyncio
 
-from opsdroid.connector import Connector
-from opsdroid.message import Message
+from opsdroid.connector import Connector, register_event
+from opsdroid.events import Message
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -100,13 +100,12 @@ class ConnectorShell(Connector):
         await self._closing.wait()
         message_processor.cancel()
 
-    async def respond(self, message, room=None):
+    @register_event(Message)
+    async def respond(self, message):
         """Respond with a message.
 
         Args:
             message (object): An instance of Message
-            room (string, optional): Name of the room to respond to.
-
         """
         _LOGGER.debug(_("Responding with: %s"), message.text)
         self.clear_prompt()


### PR DESCRIPTION
Since the event type PR was merged into the core, the shell connector stopped working as expected. Opsdroid would load the connector without any issue but when an user tried to send a message the following exception would be raised:

```python
{'message': 'Task exception was never retrieved', 'exception': TypeError("Connector <class 'opsdroid-modules.connector.shell.ConnectorShell'> can not handle the 'Message' event type.",), 'future': <Task finished coro=<OpsDroid.run_skill() done, defined at /Users/fabiorosado/Documents/GitHub/opsdroid/opsdroid/core.py:328> exception=TypeError("Connector <class 'opsdroid-modules.connector.shell.ConnectorShell'> can not handle the 'Message' event type.",)>}
```

This PR fixes the issue and makes the connector work again